### PR TITLE
Update game.cpp

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7132,8 +7132,6 @@ void game::reset_item_list_state( const catacurses::window &window, int height, 
         xpos += shortcut_print( window, point( xpos, ypos ), c_white, c_light_green,
                                 tokens[i] ) + gap_spaces;
     }
-
-    refresh_all();
 }
 
 void game::list_items_monsters()
@@ -7175,7 +7173,6 @@ void game::list_items_monsters()
         }
     }
 
-    refresh_all();
     if( ret == game::vmenu_ret::FIRE ) {
         avatar_action::fire( u, m, u.weapon );
     }
@@ -7185,7 +7182,7 @@ void game::list_items_monsters()
 game::vmenu_ret game::list_items( const std::vector<map_item_stack> &item_list )
 {
     int iInfoHeight = std::min( 25, TERMY / 2 );
-    const int width = 44;
+    const int width = 45;
     const int offsetX = TERMX - VIEW_OFFSET_X - width;
 
     catacurses::window w_items = catacurses::newwin( TERMY - 2 - iInfoHeight - VIEW_OFFSET_Y * 2,


### PR DESCRIPTION
#### Summary
```SUMMARY: Performance "remove superfluous refresh calls from list views"```

#### Purpose of change
Item/monster (shift-v) views are slow to traverse - there seem to be too many refresh calls done.

#### Describe the solution
remove superfluous refresh calls from list item/monster views
set item list width to match default/minimal monster list width (44->45)

#### Testing
Works fantastic on curses, seems to work on *nix tiles (though it's been a while since I checked), can't test on win tiles due to msys2 having some (unrelated) sdl linking problems.

**(WINDOWS TILES testing request)**
